### PR TITLE
Added various new features to the Poll Cog and fixed a bug in the display code

### DIFF
--- a/cogs/poll.py
+++ b/cogs/poll.py
@@ -6,7 +6,10 @@ import matplotlib.pyplot as plt
 from matplotlib.ticker import PercentFormatter
 import numpy as np
 import io                                       # For generating discord .png
-import os                                       # For checking if quiz file exists
+import pickle                                   # For saving all currently active quizzes
+import asyncio
+from copy import copy
+
 
 # Define a shorthand for obtaining the emoji belonging to a :emoji: string
 get_emoji = lambda em: emoji.emojize(em, use_aliases=True)
@@ -33,10 +36,9 @@ class Quiz:
         self.question = ""
         self.correct_answer = 0
         self.options = {}
+        self.timer = None
 
         self.votes = {}
-
-        self.load_data()
 
         self.emoji_options = [get_emoji(em) for em in
                               (":one:",":two:",":three:",":four:",":five:",":six:",":seven:",":eight:",":nine:")]
@@ -44,14 +46,28 @@ class Quiz:
     def load_data(self):
 
         '''Function for loading in json files containing the quiz information'''
+        try:
+            with open(self.filename, "r") as file:
+                json_data = json.load(file)
 
-        with open(self.filename, "r") as file:
-            json_data = json.load(file)
+            self.question = str(json_data["question"])
+            self.options = {i+1: str(option) for i,option in enumerate(json_data["options"])}
 
-        self.question = json_data["question"]
-        self.options = {i+1: option for i,option in enumerate(json_data["options"])}
-        self.correct_answer = json_data["correct"]
-        self.votes = {i+1: [] for i in range(len(self.options))}
+            self.correct_answer = int(json_data["correct"])
+            self.votes = {i+1: [] for i in range(len(self.options))}
+
+            # When the  file is read in, the timer specified there is used as a baseline. !makequiz and !startquiz
+            # Can overwrite this value
+            if "timer" in json_data:
+                timer_val = str(json_data["timer"])
+                self.timer = None if len(timer_val) == 0 or timer_val in ("0","-1") else int(timer_val)
+
+            succesful = True
+
+        except Exception:
+            succesful = False
+
+        return succesful, self
 
     def generate_quiz_message(self):
 
@@ -60,7 +76,7 @@ class Quiz:
         title = self.name
         question = self.question
 
-        answer_options = "\n".join(["{}) {}".format(i+1, option) for i,option in enumerate(self.options)])
+        answer_options = "\n".join([f"{i+1}) {self.options[option]}" for i,option in enumerate(self.options)])
 
         informational_text = "Answer with the emoji's given below. Only your final answer counts!"
 
@@ -95,39 +111,40 @@ class Quiz:
 
         # Create a BytesIO buffer to temporarily store the image
         image_buffer = io.BytesIO()
-        image_buffer.name = "{}_quiz_feedback.png".format(self.name)
+        image_buffer.name = f"{self.name}_quiz_feedback.png"
 
-        # Create the histogram bins for proper plotting
-        bins = np.array([i for i in range(1, len(self.options) + 2)]) - 0.5
+        # Set the plot style to be easier to view in Discord
+        plt.style.use('dark_background')
 
-        # Get the weight of the votes
+        # Get the distribution of votes in percentages
         individual_votes = np.array([len(self.votes[option]) for option in self.options])
-        weighted_votes = individual_votes/np.sum(individual_votes)
+        if np.sum(individual_votes) != 0:
+            weighted_votes = individual_votes / np.sum(individual_votes) * 100
+        else:
+            weighted_votes = np.zeros(len(self.options)) * 100
 
-        # Draw histogram
-        n, bins, patches = plt.hist(
-            [i for i in range(1,len(self.options) + 1, 1)],
-             bins=bins,
-             rwidth=0.75,
-             weights=weighted_votes
-        )
-
-        # Color correct patch green
-        patches[self.correct_answer - 1].set_facecolor('g')
-
-        # Configure grid and ticks to show percentage histogram of the answers
-        plt.gca().yaxis.set_major_formatter(PercentFormatter(1))
-        plt.grid(axis='y')
-        plt.xticks([i for i in range(1, len(self.options) + 1)])
-
-        # Configure axis labels and title
-        plt.title(self.name)
+        # Create a bar chart to represent the data
+        barchart = plt.bar(np.array(range(1,len(self.options) + 1)), weighted_votes, width=0.4, color="r")
+        plt.ylim((0,100))
+        plt.gca().yaxis.set_major_formatter(PercentFormatter())
+        plt.xticks(np.array(range(1, len(self.options) + 1)))
         plt.xlabel("Answers")
-        plt.ylabel("Votes")
 
+        # Color the correct answer green
+        barchart.patches[self.correct_answer - 1].set_facecolor("g")
+
+        # Show the values of the various bars in the bar chart above the bars
+        for bar in barchart:
+            height = bar.get_height()
+            plt.gca().text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 1.2, f"{height}%",
+                           ha='center', color='white', fontsize=15)
+
+        # Disable the left and top splines
+        [spine.set_visible(False) for i, spine in enumerate(list(plt.gca().spines.values())) if i in (1,3)]
+        plt.tick_params(bottom='off', left='off', labelleft='off', labelbottom='on')
 
         # Save figure to image buffer
-        plt.savefig(image_buffer, format="png", bbox_inches="tight")
+        plt.savefig(image_buffer, format="png", bbox_inches="tight", transparent=True)
         plt.close()
 
         # Reset the buffer internal index to the beginning
@@ -144,12 +161,57 @@ class Poll(commands.Cog):
         super().__init__()
         self.bot = bot
 
-        self.quizzes = {}
+        self.datadir = bot.datadir.joinpath('quizzes')
+        if not self.datadir.exists():
+            self.datadir.mkdir()
 
-    @commands.command("makequiz", aliases=("make-quiz","make_quiz","quiz"))
+        self.save_filepath = self.datadir.joinpath("saved_quizzes.pickle")
+
+        # This dictionary contains all the currently active quizzes
+        self.quizzes = {}
+        self.load_quizzes()
+
+    def cog_unload(self):
+
+        '''Function to handle unloading of the Poll Cog'''
+
+        # Save all active quizzes before shutdown
+        print('Unloading Poll Cog')
+        self.save_quizzes()
+        return super().cog_unload()
+
+    def save_quizzes(self):
+
+        '''Function to save a pickle object containing all the currently active quizzes'''
+
+        with open(self.save_filepath, 'wb') as file:
+            pickle.dump(self.quizzes, file)
+
+    @commands.command("savequiz",aliases=("save-quiz","save_quiz","savequizzes","save-quizzes","save_quizzes"))
     @commands.has_permissions(administrator=True)
     @commands.guild_only()
-    async def create_quiz(self,ctx,*args):
+    async def save_quiz(self,ctx):
+        self.save_quizzes()
+        await ctx.channel.send(f"<@{ctx.author.id}> Currently active quizzes saved!",
+                               delete_after=3)
+        await ctx.message.delete()
+
+    def load_quizzes(self):
+
+        '''Function to load the pickle object containing all the currently active quizzes'''
+
+        # If it doesn't exist, there is nothing to load.
+        if not self.save_filepath.exists():
+            self.save_quizzes()
+            return
+        with open(self.save_filepath, 'rb') as file:
+            self.quizzes = pickle.load(file)
+
+    @commands.command("startquiz", aliases=("start-quiz","start_quiz","quiz","beginquiz","begin-quiz",
+                                            "begin_quiz","launchquiz","launch_quiz","launch-quiz"))
+    @commands.has_permissions(administrator=True)
+    @commands.guild_only()
+    async def start_quiz(self,ctx,*args):
 
         '''Discord command to create a Quiz object and represent it in Discord'''
 
@@ -164,11 +226,18 @@ class Poll(commands.Cog):
         try:
             quiz_filename = args[0]
             quiz_name = " ".join(args[1:])
+            timer_value = None
+
+            # A timer value has also been specified, which must be extracted before proceeding.
+            if "timer=" in quiz_name.lower():
+                timer_value = int(args[-1].lower().strip("timer="))
+                timer_value = timer_value if timer_value > 0 else None
+                quiz_name = " ".join(args[1:-1])
+
         except Exception:
             await ctx.channel.send(
-                "<@{}> Command used incorrectly! Please provide the filename first, then the quiz name".format(
-                    ctx.author.id
-                ),
+                f"<@{ctx.author.id}> Command used incorrectly! Please provide the filename first, then the quiz name. "
+                f"Optionally, a time limit can be specified using timer=xx",
                 delete_after=3
             )
             return
@@ -177,20 +246,32 @@ class Poll(commands.Cog):
         if not ".json" in quiz_filename:
             quiz_filename += ".json"
 
+        quiz_filepath = self.datadir.joinpath(quiz_filename)
+
         # Check if the filename specified actually exists
-        if not os.path.exists(quiz_directory+quiz_filename):
+        if not quiz_filepath.exists():
             await ctx.channel.send(
-                "<@{}> The filename provided does not seem to exist, please check spelling and try again.".format(
-                    ctx.author.id
-                ),
+                f"<@{ctx.author.id}> The filename provided does not seem to exist, please check spelling and try again.",
                 delete_after=3
             )
             return
 
         # Create the new quiz
-        new_quiz = Quiz(quiz_name,quiz_directory+quiz_filename,quiz_creator)
+        was_succesful, new_quiz = Quiz(quiz_name,quiz_filepath,quiz_creator).load_data()
 
-        # Create the message belonging to the quiz and give it a nice green coloured embed
+        # Abort if the data reading has failed. If the bot has been properly configured, this means that the json
+        # formatting is wrong.
+        if not was_succesful:
+            await ctx.channel.send(
+                f"<@{ctx.author.id}> The json quiz file has been improperly formatted!",
+                delete_after=5
+            )
+            return
+
+        if timer_value:
+            new_quiz.timer = timer_value
+
+        # Create the message belonging to the quiz and give it a green coloured embed
         title, description, emojis = new_quiz.generate_quiz_message()
         embed = discord.Embed(title=title, description=description, colour=0x41f109)
         new_message = await quiz_channel.send(embed=embed)
@@ -206,6 +287,11 @@ class Poll(commands.Cog):
         for em in emojis:
             await new_message.add_reaction(em)
 
+        # If the quiz has a timer, activate it
+        if new_quiz.timer:
+            self.bot.loop.create_task(self.quiz_timer(new_quiz.timer,new_message))
+
+
     @commands.command("finishquiz", aliases=("finish-quiz", "finish_quiz", "endquiz","end_quiz","end-quiz"))
     @commands.has_permissions(administrator=True)
     @commands.guild_only()
@@ -216,38 +302,49 @@ class Poll(commands.Cog):
         It sends the histogram to the channel where the quiz resides as well as the people who started
         and ended the quiz.
         """
+        # If this is the case, then this was not an internal function call and it was an actual command
+        if not type(ctx) == int:
+            # Save the author and channel for future reference
+            author_id = ctx.author.id
+            message_channel = ctx.channel
 
-        # Save the author and channel for future reference
-        author_id = ctx.author.id
-        message_channel = ctx.channel
+            # Delete the message containing the command
+            await ctx.message.delete()
 
-        # Delete the message containing the command
-        await ctx.message.delete()
+            quiz_name = " ".join(args)
 
-        quiz_name = " ".join(args)
-        try:
-            quiz_to_finish = self.quizzes[list(filter(lambda k: self.quizzes[k].name, self.quizzes))[0]]
-        except Exception:
-            await ctx.channel.send(
-                "<@{}> That quiz does not exist, please check the spelling of the name you provided!".format(
-                    ctx.author.id
-                ),
-                delete_after=3
-            )
-            return
+            try:
+                quiz_to_finish = self.quizzes[list(filter(lambda k: self.quizzes[k].name, self.quizzes))[0]]
+            except Exception:
+                await ctx.channel.send(
+                    f"<@{ctx.author.id}> That quiz does not exist, please check the spelling of the name you provided!",
+                    delete_after=3
+                )
+                return
+
+        # The function was called internally by quiz_timer
+        else:
+            # Check if the quiz has been ended in the meantime
+            if not ctx in self.quizzes:
+                return
+            quiz_to_finish = self.quizzes[ctx]
+            author_id = quiz_to_finish.owner
+            message_channel = self.bot.get_channel(quiz_to_finish.channel_id)
 
         feedback_chart = quiz_to_finish.create_histogram()
 
+        file_object = discord.File(feedback_chart, filename=feedback_chart.name)
+        embed = discord.Embed(title=f"Feedback for {quiz_to_finish.name}", colour=0x41f109)
+        embed.set_image(url=f"attachment://{feedback_chart.name}")
+
         # Send the feedback chart to the channel where the quiz is located
-        await self.bot.get_channel(quiz_to_finish.channel_id).send("Feedback graph for {}!".format(quiz_to_finish.name),
-                                                                   file=discord.File(feedback_chart))
+        await self.bot.get_channel(quiz_to_finish.channel_id).send(embed=embed,file=file_object)
 
         # Send the feedback chart to the person who created the quiz and the person who ended it
         for user_id in {author_id, quiz_to_finish.owner}:
             # Reset the buffer internal index to 0 again
             feedback_chart.seek(0)
-            await message_channel.guild.get_member(user_id).send("Feedback graph for {}!".format(quiz_to_finish.name),
-                                                                 file=discord.File(feedback_chart))
+            await message_channel.guild.get_member(user_id).send(embed=embed,file=file_object)
         # Remove the quiz from the internal dictionary
         self.quizzes.pop(quiz_to_finish.message_id)
 
@@ -268,6 +365,68 @@ class Poll(commands.Cog):
 
         # Call the vote command. If an invalid emoji has been used, this will do nothing
         self.quizzes[message_id].vote(reaction_member.id, str(ctx.emoji))
+
+    @commands.command("makequiz", aliases=("make_quiz","make-quiz","create-quiz","create_quiz","createquiz"))
+    @commands.has_permissions(administrator=True)
+    @commands.guild_only()
+    async def create_quiz(self,ctx, *args):
+
+        '''Function to create a quiz json file using either a file attachment or a json string directly'''
+
+        if len(args) == 0:
+            await ctx.channel.send(f"<@{ctx.author.id}> No arguments were given!",
+                                   delete_after=3)
+            return
+
+        # If a file has been attached, this means the quiz is attached in a json file format
+        if len(ctx.message.attachments) > 0:
+            # In this case, the command usage dictates that the argument is the filename that should be used
+            # to save the json file.
+            file_name = " ".join(args).rstrip(".json")
+            file_name += ".json"
+            await ctx.message.attachments[0].save(self.datadir.joinpath(file_name), use_cached=False, seek_begin=True)
+            await ctx.message.delete()
+            return
+
+        # If not, the json data must be given as an argument
+        if not len(args) >= 4:
+            await ctx.channel.send(f"<@{ctx.author.id}> Incorrect usage of command! Either attach the json file to "
+                                   f"the message and provide the filename as argument provide filename, question, "
+                                   f"answers and correct response as separate arguments.",
+                                   delete_after=6)
+            return
+        timer_value = ''
+        # A timer value was added, which needs to be extracted now
+        if len(args) == 5:
+            timer_value = f', "timer":{args[4].lower().strip("timer=")}'
+            args = args[:-1]
+
+        file_name = args[0].rstrip(".json") + ".json"
+        json_string = '{{"question": "{}", "options": [{}], "correct": {}{}}}'.format(*args[1:], timer_value)
+
+        with open(self.datadir.joinpath(file_name), 'w') as file:
+            file.write(json_string)
+
+        await ctx.message.delete()
+
+    async def quiz_timer(self, timer_duration, message_object):
+        '''Function to dynamicall update the timer value on a quiz and automatically end it'''
+        timer = timer_duration
+        t = lambda x: f"{0 if x//60 < 10 else ''}{x // 60}:{0 if x % 60 < 10 else ''}{x % 60}{0 if x % 60 == 0 else ''}"
+
+        # Extract the embed from the message and get it's original title
+        embed = message_object.embeds[0]
+
+        while timer > 0:
+            new_timer_value = f"Time left: {t(timer)}"
+            embed.set_footer(text=new_timer_value)
+            await message_object.edit(embed=embed)
+            await asyncio.sleep(1)
+            timer -= 1
+
+        await self.finish_quiz(message_object.id)
+
+
 
 
 


### PR DESCRIPTION
This update to the Poll Cog has the following changes:

- !makequiz and its aliases are now !startquiz, !makequiz is now a new command to add new quizzes to the local json database through either supplying the details for the quiz in the command or through attaching a json file to the message and supplying the desired filename as command argument.
- Save/load functionality added, save location is relative to bot.datadir
- Fixed a bug in the quiz display code
- Revised the feedback graph generation. It now uses a new visual style, has a transparent background, displays the information in a clearer way and uses plt.bar instead of plt.hist. In addition, it is now supplied in an Embed to keep a uniform visual style.
- The addition of an optional timer in quizzes, after which the quiz will be automatically ended. The timer can be optionally configured in two ways if desired: included in the quiz template or specified during !startquiz by adding timer=xx to the end of the command message. e.g. "!startquiz test_quiz.json Test quiz timer=25. The timer display code will not display the time remaining correctly if a timer of longer than one hour is supplied.