### PR TITLE
Add ability to run EduBot from Command Prompt

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ install_requires =
     matplotlib
     emoji
     Deprecated
+    Click
 setup_requires =
     setuptools_scm
     setuptools >= 40

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,10 @@ tests_require =
 [options.packages.find]
 where = src
 
+[options.entry_points]
+console_scripts =
+    edubot = edubot.run:cli
+
 [options.extras_require]
 dev =
     pytest

--- a/src/edubot/bot.py
+++ b/src/edubot/bot.py
@@ -17,13 +17,12 @@
 
 """Contains the main :py:class:`EduBot` specification."""
 
-import os
 from pathlib import Path
 
 import discord
 from discord.ext import commands
 
-from edubot.cogs import Poll, QueueCog
+from .cogs import Poll, QueueCog
 
 
 class EduBot(commands.Bot):
@@ -56,9 +55,3 @@ class EduBot(commands.Bot):
             if not user.dm_channel:
                 await user.create_dm()
             await user.dm_channel.send(message)
-
-
-if __name__ == "__main__":
-    TOKEN = os.getenv("DISCORD_TOKEN")
-    bot = EduBot()
-    bot.run(TOKEN)

--- a/src/edubot/run.py
+++ b/src/edubot/run.py
@@ -1,0 +1,47 @@
+# Discord bot for the TU Delft Aerospace Engineering Python course
+# Copyright (C) 2020 Delft University of Technology
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+
+"""Contains the :py:func:`cli` the entry-point of EduBot."""
+
+
+import os
+
+import click
+
+from .bot import EduBot
+
+TOKEN = os.getenv("DISCORD_TOKEN")
+
+
+@click.command()
+@click.option("--token", default=TOKEN, help="Specifies the Discord API Token")
+def cli(token: str):
+    """Command Line Interface (CLI) of :py:class:`Edubot`.
+
+    Args:
+        token: Discord API Token
+
+    """
+    assert token is not None, "No Discord API token could be retrieved"
+    bot = EduBot()
+    bot.run(token)
+    return bot
+
+
+if __name__ == "__main__":
+    # Prevents gc (garbage-collection) of the bot
+    bot = cli()

--- a/src/edubot/run.py
+++ b/src/edubot/run.py
@@ -15,7 +15,7 @@
 # License along with this program.
 # If not, see <https://www.gnu.org/licenses/>.
 
-"""Contains the :py:func:`cli` the entry-point of EduBot."""
+"""Contains the :py:func:`cli` to run EduBot from command-line."""
 
 
 import os
@@ -43,5 +43,4 @@ def cli(token: str):
 
 
 if __name__ == "__main__":
-    # Prevents gc (garbage-collection) of the bot
-    bot = cli()
+    bot = cli()  # Assignment of the bot prevents gc (garbage-collection)

--- a/src/edubot/run.py
+++ b/src/edubot/run.py
@@ -23,7 +23,22 @@ from typing import Optional
 
 import click
 
-from edubot.bot import EduBot
+try:
+    from edubot.bot import EduBot
+except ImportError as e:  # Edubot is not installed
+    if not __package__:
+        # run.py is being run locally as a script
+        import sys
+        import inspect
+
+        filepath = inspect.getfile(inspect.currentframe())  # path of run.py
+        sys.path.insert(0, os.path.join(os.path.dirname(filepath), ".."))
+        from edubot.bot import EduBot
+    else:
+        # Something went very wrong, EduBot is not installed and run.py
+        # is imported as a package. This is deffinitely not the intended
+        # usage so we raise the exception
+        raise e
 
 TOKEN = os.getenv("DISCORD_TOKEN")
 

--- a/src/edubot/run.py
+++ b/src/edubot/run.py
@@ -15,14 +15,15 @@
 # License along with this program.
 # If not, see <https://www.gnu.org/licenses/>.
 
-"""Contains the :py:func:`cli` to run EduBot from command-line."""
+"""Contains functions and classes for running :py:class:`EduBot`."""
 
-
+import asyncio
 import os
+from typing import Optional
 
 import click
 
-from .bot import EduBot
+from edubot.bot import EduBot
 
 TOKEN = os.getenv("DISCORD_TOKEN")
 
@@ -36,11 +37,83 @@ def cli(token: str):
         token: Discord API Token
 
     """
-    assert token is not None, "No Discord API token could be retrieved"
-    bot = EduBot()
-    bot.run(token)
-    return bot
+    return BotRunner(token)
+
+
+class BotRunner:
+    """Runs :py:class:`EduBot` in the standard blocking manner."""
+
+    def __init__(self, token: Optional[str] = TOKEN):
+        self.validate_token(token)
+        self.bot = EduBot()
+        self.run(token)
+
+    def run(self, token):
+        """Runs the bot with the given ``token`` as a blocking call."""
+        self.bot.run(token)
+
+    # TODO find a better validation method later or remove completely
+    @staticmethod
+    def validate_token(token: str) -> None:
+        """Ensures that the provided ``token`` is valid."""
+        _error_msg = "No Discord API token could be retrieved"
+        assert isinstance(token, str) and len(token) != 0, _error_msg
+
+
+class InteractiveBotRunner(BotRunner):
+    """Runs :py:class:`EduBot` in a non-blocking manner.
+
+    This is suitable for running the bot with interactive consoles such
+    as IPython.
+
+    Caution:
+        No clean-up action will be called after the Interactive Console
+        is closed therefore no saving operations will take place. DO NOT
+        USE THIS FOR ACTUAL SESSIONS!
+    """
+
+    def __init__(self, token: Optional[str] = TOKEN):
+        self.loop = asyncio.get_event_loop()
+        self.loop.set_debug(True)
+        super().__init__(token)
+
+    def run(self, token):
+        """Retrieves the active event loop and runs the bot on it.
+
+        By retrieving the event-loop (if it exists) with
+        :py:func:`asyncio.get_event_loop`, we guarantee that the
+        :py:class:`EduBot` will integrate into the already present
+        event-loop of the interactive console (IPython).
+        """
+        self.create_task(self.bot.start(token))
+
+    def create_task(self, task):
+        """Runs a given ``task`` asynchroniously using asyncio.
+
+        The purpose of this function is to simply reduce the amount of
+        code that needs to be typed when a command needs to be issued
+        from within the interactive console. All this method does is
+        call :py:func:`asyncio.loop.create_task` on the given ``task``.
+        """
+        self.loop.create_task(task)
+
+
+def is_ipython() -> bool:
+    """Determines if IPython is currently running.
+
+    Note:
+        Encapsulating the `get_ipython` call with this function avoids
+        having to force developers/users to install IPython for the rest
+        of the functionality to work.
+    """
+    try:
+        from IPython import get_ipython
+
+        return get_ipython()
+    except ImportError:
+        return False
 
 
 if __name__ == "__main__":
-    bot = cli()  # Assignment of the bot prevents gc (garbage-collection)
+    runner = InteractiveBotRunner(TOKEN) if is_ipython() else BotRunner(TOKEN)
+    bot = runner.bot

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,0 @@
-''' Main script to start EduBot. '''
-import os
-from edubot import EduBot
-
-
-if __name__ == "__main__":
-    TOKEN = os.getenv("DISCORD_TOKEN")
-    bot = EduBot()
-    bot.run(TOKEN)


### PR DESCRIPTION
This allows for the following running `EduBot` from a command prompt as follows:
``` cmd
edubot
```
Also it's possible to specify a Discord Token which could be useful later when deploying to a server.
``` cmd
edubot --token=XYZ
```

The functionality of the `main.py` file we thought of before has also been added to the new `run.py` file inside `src/edubot`. Currently the `run.py` file supports the following ways of launching EduBot.

1. Running as a Python script (also works within IDLE since the sys.path is modified)
    b. User called `python src/edubot/run.py`:  `BotRunner` is initialized and launched
    a. User asked for an interactive console`ipython; %run src/edubot/run.py`: IPython is detected and `InteractiveBotRunner` is initialized and launched.
2. Running by importing the `BotRunner` or `InteractiveBotRunner` classes from `edubot.run`
3. Running through the command-prompt with the `edubot` command

I'm quite excited to play with usage 1a as it means we can issue commands and observe variables while the bot is running and connected to the server!