### PR TITLE
Repair !fromhistory; delete messages after commands

### DIFF
--- a/src/edubot/cogs/queue.py
+++ b/src/edubot/cogs/queue.py
@@ -417,7 +417,8 @@ class QueueCog(commands.Cog):
     async def queueme(self, ctx, *args):
         """ Add me to the queue in this channel """
         qid = (ctx.guild.id, ctx.channel.id)
-        await ctx.send(Queue.addtoqueue(qid, ctx.author.id))
+        ctx.message.delete()
+        await ctx.send(Queue.addtoqueue(qid, ctx.author.id), delete_after=4)
 
     @commands.command(aliases=('ask',))
     @commands.check(lambda ctx: Queue.qcheck(ctx, 'Question'))
@@ -445,7 +446,8 @@ class QueueCog(commands.Cog):
     async def whereami(self, ctx):
         """ What's my position in the queue of this channel. """
         uid = ctx.author.id
-        await ctx.send(Queue.queues[(ctx.guild.id, ctx.channel.id)].whereis(uid))
+        await ctx.message.delete()
+        await ctx.send(Queue.queues[(ctx.guild.id, ctx.channel.id)].whereis(uid), delete_after=4)
 
     @commands.command()
     @commands.check(lambda ctx: Queue.qcheck(ctx, 'Review'))


### PR DESCRIPTION
- Misunderstanding of `message.reactions` output led to
  all 'Ready' messages to be considered unchecked
- Added logic to clean up old commands, even if issued
  by TA/Tutor accounts
- Replaced front fill with self.add, to use logic of
  self.add function -> No user twice in queue.
- Print overview of actions performed by bot.