### PR TITLE
MultiQueue Functionality

### DIFF
--- a/src/edubot/cogs/queue.py
+++ b/src/edubot/cogs/queue.py
@@ -903,6 +903,13 @@ class QueueCog(commands.Cog):
     @commands.check(lambda  ctx: Queue.qcheck(ctx, ['Review', 'MultiReview']))
     @commands.has_permissions(administrator=True)
     async def toggleReview(self, ctx, aid):
+        """Toggles whether an assignment is being handled
+
+        In a ReviewQueue this merely indicates in the Indicator if it's being accepted.
+        In a MultiReviewQueue this adds and removes queues.
+        Arguments:
+            - aid: Assignment number.
+        """
         qid = (ctx.guild.id, ctx.channel.id)
         await ctx.message.delete()
         if aid is None:
@@ -916,6 +923,11 @@ class QueueCog(commands.Cog):
     @commands.check(lambda  ctx: Queue.qcheck(ctx, 'Review'))
     @commands.has_permissions(administrator=True)
     async def convert(self, ctx, aid='1'):
+        """Function to convert from Review to MultiReview
+
+        Arguments:
+            - aid: Assignment number for first queue, if none already enabled.
+              Defaults to 1"""
         qid = (ctx.guild.id, ctx.channel.id)
         await ctx.message.delete()
         if Queue.queues[qid].qtype == 'Review':

--- a/src/edubot/cogs/queue.py
+++ b/src/edubot/cogs/queue.py
@@ -749,7 +749,7 @@ class QueueCog(commands.Cog):
         if aid:
             await Queue.queues[qid].takenext(ctx, aid)
         else:
-        await Queue.queues[qid].takenext(ctx)
+            await Queue.queues[qid].takenext(ctx)
         await Queue.queues[qid].updateIndicator(ctx)
 
     @takenext.command()

--- a/src/edubot/cogs/queue.py
+++ b/src/edubot/cogs/queue.py
@@ -71,7 +71,7 @@ class Queue:
             await ctx.send('This channel doesn\'t have a queue!', delete_after=20)
             await ctx.message.delete(delay=20)
             return False
-        if not qtype or qtype == queue.qtype:
+        if not qtype or qtype == queue.qtype or queue.qtype in qtype:
             return True
         await ctx.send(f'{ctx.invoked_with} is not a recognised command for the queue in this channel!', delete_after=20)
         await ctx.message.delete(delay=20)
@@ -677,7 +677,7 @@ class QueueCog(commands.Cog):
         await ctx.send(Queue.loadall())
 
     @commands.command()
-    # @commands.check(lambda ctx: Queue.qcheck(ctx, 'Review'))
+    @commands.check(lambda ctx: Queue.qcheck(ctx, ['Review', 'MultiReview']))
     @commands.has_permissions(administrator=True)
     async def takenext(self, ctx):
         """ Take the next in line from the queue. """
@@ -690,7 +690,7 @@ class QueueCog(commands.Cog):
         await Queue.queues[qid].updateIndicator(ctx)
 
     @commands.command()
-    # @commands.check(lambda ctx: Queue.qcheck(ctx, 'Review'))
+    @commands.check(lambda ctx: Queue.qcheck(ctx, ['Review', 'MultiReview']))
     @commands.has_permissions(administrator=True)
     async def putback(self, ctx, pos : int = 10):
         ''' Put the student you currently have in your voice channel back in the queue.
@@ -733,7 +733,7 @@ class QueueCog(commands.Cog):
         await ctx.send(Queue.load((ctx.guild.id, ctx.channel.id)))
 
     @commands.command(aliases=('ready', 'done'))
-    # @commands.check(lambda ctx: Queue.qcheck(ctx, 'Review'))
+    @commands.check(lambda ctx: Queue.qcheck(ctx, ['Review', 'MultiReview']))
     async def queueme(self, ctx, *args):
         """ Add me to the queue in this channel. """
         print('outer queueme command')
@@ -854,7 +854,7 @@ class QueueCog(commands.Cog):
         await Queue.queues[qid].updateIndicator(ctx)
 
     @commands.command('toggle', aliases=('toggleReview',))
-    @commands.check(lambda  ctx: Queue.qcheck(ctx, 'MultiReview'))
+    @commands.check(lambda  ctx: Queue.qcheck(ctx, ['Review', 'MultiReview']))
     @commands.has_permissions(administrator=True)
     async def toggleReview(self, ctx, aid):
         qid = (ctx.guild.id, ctx.channel.id)

--- a/src/edubot/cogs/queue.py
+++ b/src/edubot/cogs/queue.py
@@ -314,12 +314,11 @@ class MultiReviewQueue(Queue):
             else:
                 readied = student.aid
                 plural = (True if len(readied) > 1 else False)
-                msg += f'<@{uid}>, you have joined the following queue' + \
+                msg += f'<@{uid}>, are in queue' + \
                        ('s: ' if plural else ': ') + \
-                       f'{", ".join(str(i) for i in readied)}'
-                msg += "\nYou are at positions:\n"
-                for queue in readied:
-                    msg += f"Position in queue {queue}: {self.queue[queue].index(uid)+1} of {len(self.queue[queue])}\n"
+                       f'{", ".join(str(i) for i in readied)}' + '. '
+                msg += f"You are at position{'s' if plural else ''}:"
+                msg += f'{", ".join(f"{self.queue[queue].index(uid)+1} of {len(self.queue[queue])}")}'
             await ctx.channel.send(msg, delete_after=20)
             return
 


### PR DESCRIPTION
Creates a new subclass named the MultiReviewQueue. Has the following extra features:

- Brand new Indicator Embed, with tiled queue stats

- Compatible with normal load/save commands

- Toggle queue hand ins

- Support removing people from multiple queues simultaneously

- !takenext can select which queue to take from, defaults to first queue