### PR TITLE
In session error identified as problem in putback

### DIFF
--- a/src/edubot/cogs/queue.py
+++ b/src/edubot/cogs/queue.py
@@ -377,7 +377,7 @@ class MultiReviewQueue(Queue):
 
         if aid in self.assignments: # Queue exists?
             try: # Student in queue?
-            pos = self.queue[aid].index(student.id)
+                pos = self.queue[aid].index(student.id)
                 msg = f"Hi <@{student.id}>, you're already in queue {aid}! " + \
                     (f"There are still {pos} people waiting in front of you." if pos else
                         'You are next in line!')

--- a/src/edubot/cogs/queue.py
+++ b/src/edubot/cogs/queue.py
@@ -27,7 +27,7 @@ from discord.ext import commands
 re_ask = re.compile(r'(?:!ask|!question)\s*(.*)')
 
 # Generate ordinal strings for queue positions
-ordinal = lambda n: "%d%s" % (n,"tsnrhtdd"[(n//10%10!=1)*(n%10<4)*n%10::4])
+ordinal = lambda n: f'{n}{"tsnrhtdd"[(n//10%10!=1)*(n%10<4)*n%10::4]}'
 
 
 def getvoicechan(member):


### PR DESCRIPTION
The putback command did not restore the aid to the student.aid list, but used in the takenext command. This led to students being in the self.queue[aid] multiple times, but not being able to be taken from the queue.

sundry changes:
 - robust MultiQueue -> SingleQueue conversion, for when that's required
 - whereami works in MultiQueue now
 - removeme can be used to exit only one subqueue